### PR TITLE
Fixes to make 'curl' option workable

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -189,7 +189,7 @@ export default {
           args.push('declarative-linter');
         }
         // curl methods
-        else if /^CURL/.test(atom.config.get('linter-jenkins.lintMethod')) {
+        else if (/^CURL/.exec(atom.config.get('linter-jenkins.lintMethod'))) {
           cmd = 'curl'
 
           // determine curl arguments

--- a/lib/main.js
+++ b/lib/main.js
@@ -189,16 +189,16 @@ export default {
           args.push('declarative-linter');
         }
         // curl methods
-        else if (atom.config.get('linter-jenkins.lintMethod') == 'CURL') {
+        else if /^CURL/.test(atom.config.get('linter-jenkins.lintMethod')) {
           cmd = 'curl'
 
           // determine curl arguments
           if (atom.config.get('linter-jenkins.curl.useCrumb')) {
             crumb = helpers.exec('curl', [`${atom.config.get(linter-jenkins.curl.httpURI)}/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)`]);
-            args = ['-X', 'POST', '-H', crumb, '-F', `jenkinsfile=${content}`, `${atom.config.get(linter-jenkins.curl.httpURI)}/pipeline-model-converter/validate`];
+            args = ['--silent', '-X', 'POST', '-H', crumb, '-F', `jenkinsfile=${content}`, `${atom.config.get('linter-jenkins.curl.httpURI')}/pipeline-model-converter/validate`];
           }
           else
-            args = ['-X', 'POST', '-F', `jenkinsfile=${content}`, `${atom.config.get(linter-jenkins.curl.httpURI)}/pipeline-model-converter/validate`];
+            args = ['--silent', '-X', 'POST', '-F', `jenkinsfile=${content}`, `${atom.config.get('linter-jenkins.curl.httpURI')}/pipeline-model-converter/validate`];
         }
 
         // lint


### PR DESCRIPTION
* Fixed pattern match for lintMethod
* Added 'silent' option to curl args to avoid extraneous noise
* Added missing quotes around atom.config.get() arguments