### PR TITLE
useCrumb option fix in CURL method

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -194,7 +194,11 @@ export default {
 
           // determine curl arguments
           if (atom.config.get('linter-jenkins.curl.useCrumb')) {
-            crumb = helpers.exec('curl', [`${atom.config.get('linter-jenkins.curl.httpURI')}/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)`]);
+            crumbRequest = helpers.exec(cmd, ['--silent', `${atom.config.get('linter-jenkins.curl.httpURI')}/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)`]);
+            crumbRequest.then(response => {
+              localStorage.setItem("jenkinsCrumb", response);
+            });
+            crumb = localStorage.getItem("jenkinsCrumb");
             args = ['--silent', '-X', 'POST', '-H', crumb, '-F', `jenkinsfile=${content}`, `${atom.config.get('linter-jenkins.curl.httpURI')}/pipeline-model-converter/validate`];
           }
           else


### PR DESCRIPTION
Hi, thanks for the package!

Currently useCrumb options does not work at all.
I am not good at JS so the only way I found to pass crumb to the second request is using of localStorage.

Please consider the fix or perform it on your own.

Thanks,
Dmitriy