### PR TITLE
fix insecure curl argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.0.6
+- Fix curl insecure argument
+
 ### 1.0.5
 - Add option to disable strict host key checking on SSH methods.
 - Add `user:password|token` authentication option for CURL method.

--- a/lib/main.js
+++ b/lib/main.js
@@ -246,10 +246,10 @@ export default {
             });
             crumb = localStorage.getItem('jenkinsCrumb');
 
-            args = ['-L', '-s', '-X', 'POST', '-H', crumb, '-F', `jenkinsfile=${content}`];
+            args += ['-L', '-s', '-X', 'POST', '-H', crumb, '-F', `jenkinsfile=${content}`];
           }
           else
-            args = ['-L', '-s', '-X', 'POST', '-F', `jenkinsfile=${content}`];
+            args += ['-L', '-s', '-X', 'POST', '-F', `jenkinsfile=${content}`];
 
           // check if auth token configured and utilze if so
           if (atom.config.get('linter-jenkins.curl.authToken') != '')


### PR DESCRIPTION
The '-k' option here gets ignored because args is rewritten later.

https://github.com/mschuchard/linter-jenkins/blob/1be7791df1372fa94dcf3e7987d3ae64285b07b3/lib/main.js#L230