### PR TITLE
Bugfix: Array.push updates the array in place and returns the length …

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -253,7 +253,7 @@ export default {
 
           // check if auth token configured and utilze if so
           if (atom.config.get('linter-jenkins.curl.authToken') != '')
-            args = args.push(...['--user', atom.config.get('linter-jenkins.curl.authToken')]);
+            args.push(...['--user', atom.config.get('linter-jenkins.curl.authToken')]);
 
           args.push(`${atom.config.get('linter-jenkins.curl.httpURI')}/pipeline-model-converter/validate`);
         }


### PR DESCRIPTION
…of the array

I ran into this issue when trying to get this great plugin to work for my environment!

When authentication details are provided for the CURL function of the linter, the `args` variable gets set to an integer on line 256, and then throws an error on line 258: 

`[Linter] Error running Jenkins TypeError: args.push is not a function`

This quick fix should tackle that issue! Thanks for making a great plugin!