### PR TITLE
added websocket property in cli http method

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -64,6 +64,12 @@ export default {
           description: 'Check the certificate during the connection (HTTP only).',
           default: false,
         },
+        webSocket: {
+          title: 'Use Websocket',
+          type: 'boolean',
+          description: 'Use websocket as an alternative to -http ( for Jenkins 2.217 and above).',
+          default: false,
+        },
         user: {
           title: 'SSH User',
           type: 'string',
@@ -205,6 +211,9 @@ export default {
           // determine cli arguments
           if (atom.config.get('linter-jenkins.lintMethod') == 'CLI and HTTP') {
             args = ['-jar', atom.config.get('linter-jenkins.cli.cliJar'), '-s', atom.config.get('linter-jenkins.cli.httpURI'), '-auth', atom.config.get('linter-jenkins.cli.authToken')];
+            // add using websocket
+            if ((atom.config.get('linter-jenkins.cli.webSocket')))
+              args.push('-webSocket')
             // add no cert checking if specified
             if (!(atom.config.get('linter-jenkins.cli.cert')))
               args.push('-noCertificateCheck')


### PR DESCRIPTION
In Jenkins 2.217 and above added websocket conection mode
Found that information in [https://www.jenkins.io/doc/book/managing/cli/](url)
In my case this helped me to use that linter